### PR TITLE
[RFC] video splash image

### DIFF
--- a/src/Elements/Vimeo.php
+++ b/src/Elements/Vimeo.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+namespace Brkwsky\PrivacyConsentBundle\Elements;
+
+use Contao\ContentVimeo;
+use Contao\FilesModel;
+use Contao\StringUtil;
+
+/**
+ * {@inheritdoc}
+ */
+class Vimeo extends ContentVimeo
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function compile()
+    {
+        if ($this->videoSplash)
+        {
+            $imageSize = StringUtil::deserialize($this->size);
+            $objFile = FilesModel::findByUuid($this->singleSRC);
+
+            if ($objFile !== null && \is_file(TL_ROOT . '/' . $objFile->path))
+            {
+                $this->singleSRC = $objFile->path;
+                $objSplash = new \stdClass();
+                $this->addImageToTemplate($objSplash, $this->arrData, null, null, $objFile);
+                $this->Template->splashImage = $objSplash;
+                $this->autoplay = true;
+            }
+            else
+            {
+                $this->videoSplash = false;
+            }
+        }
+
+        $size = StringUtil::deserialize($this->playerSize);
+
+        if (!\is_array($size) || empty($size[0]) || empty($size[1]))
+        {
+            $this->Template->width = 640;
+            $this->Template->height = 360;
+        }
+        else
+        {
+            $this->Template->width = $size[0];
+            $this->Template->height = $size[1];
+        }
+
+        parent::compile();
+    }
+}

--- a/src/Elements/YouTube.php
+++ b/src/Elements/YouTube.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+namespace Brkwsky\PrivacyConsentBundle\Elements;
+
+use Contao\ContentYouTube;
+use Contao\FilesModel;
+use Contao\StringUtil;
+
+/**
+ * {@inheritdoc}
+ */
+class YouTube extends ContentYouTube
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function compile()
+    {
+        if ($this->videoSplash)
+        {
+            $imageSize = StringUtil::deserialize($this->size);
+            $objFile = FilesModel::findByUuid($this->singleSRC);
+
+            if ($objFile !== null && \is_file(TL_ROOT . '/' . $objFile->path))
+            {
+                $this->singleSRC = $objFile->path;
+                $objSplash = new \stdClass();
+                $this->addImageToTemplate($objSplash, $this->arrData, null, null, $objFile);
+                $this->Template->splashImage = $objSplash;
+                $this->autoplay = true;
+            }
+            else
+            {
+                $this->videoSplash = false;
+            }
+        }
+
+        $size = StringUtil::deserialize($this->playerSize);
+
+        if (!\is_array($size) || empty($size[0]) || empty($size[1]))
+        {
+            $this->Template->width = 640;
+            $this->Template->height = 360;
+        }
+        else
+        {
+            $this->Template->width = $size[0];
+            $this->Template->height = $size[1];
+        }
+
+        parent::compile();
+    }
+}

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+/**
+ * Content elements
+ */
+$GLOBALS['TL_CTE']['media']['youtube'] = 'Brkwsky\PrivacyConsentBundle\Elements\YouTube';
+$GLOBALS['TL_CTE']['media']['vimeo'] = 'Brkwsky\PrivacyConsentBundle\Elements\Vimeo';

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_DCA']['tl_content']['fields']['videoSplash'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_content']['videoSplash'],
+    'exclude'                 => true,
+    'inputType'               => 'checkbox',
+    'eval'                    => array('submitOnChange'=>true, 'tl_class'=>'clr w50'),
+    'sql'                     => "char(1) NOT NULL default ''"
+);
+
+/**
+ * Palettes
+ */
+PaletteManipulator::create()
+    ->addField('videoSplash', 'player_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('youtube', 'tl_content')
+    ->applyToPalette('vimeo', 'tl_content');
+
+$GLOBALS['TL_DCA']['tl_content']['palettes']['__selector__'][] = 'videoSplash';
+$GLOBALS['TL_DCA']['tl_content']['subpalettes']['videoSplash'] = 'singleSRC,size';

--- a/src/Resources/contao/languages/de/tl_content.php
+++ b/src/Resources/contao/languages/de/tl_content.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_content']['videoSplash'] = ['Splash image', 'Das Video wird erst per iframe eingebunden wenn ein Splash image angeklickt wird.'];

--- a/src/Resources/contao/languages/en/tl_content.php
+++ b/src/Resources/contao/languages/en/tl_content.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright   Christian Barkowsky 2018 <https://brkwsky.de>
+ * @author      Fritz Michael Gschwantner <https://github.com/fritzmg>
+ * @package     PrivacyConsentBundle
+ * @license     LGPL-3.0-or-later
+ * @see         https://github.com/christianbarkowsky/contao-privacyconsent-bundle
+ */
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_content']['videoSplash'] = ['Splash image', 'The video will be integrated only if the user clicks on a splash image.'];

--- a/src/Resources/contao/templates/ce_vimeo.html5
+++ b/src/Resources/contao/templates/ce_vimeo.html5
@@ -1,0 +1,24 @@
+
+<?php $this->extend('block_unsearchable'); ?>
+
+<?php $this->block('content'); ?>
+
+  <?php if ($this->videoSplash): ?>
+    <figure id="videoSplash<?= $this->id ?>" class="image_container" data-video="<?= $this->src ?>">
+      <?php $this->insert('picture_default', $this->splashImage->picture); ?>
+    </figure>
+    <script>
+      document.getElementById('videoSplash<?= $this->id ?>').addEventListener('click', function(e) {
+        var iframe = document.createElement('iframe');
+        iframe.src = this.dataset['video'];
+        iframe.width = <?= $this->width; ?>;
+        iframe.height = <?= $this->height; ?>;
+        iframe.allowfullscreen = '';
+        this.parentNode.replaceChild(iframe, this);
+      });
+    </script>
+  <?php else: ?>
+    <iframe<?= $this->size ?> src="<?= $this->src ?>" allowfullscreen></iframe>
+  <?php endif; ?>
+
+<?php $this->endblock(); ?>

--- a/src/Resources/contao/templates/ce_youtube.html5
+++ b/src/Resources/contao/templates/ce_youtube.html5
@@ -1,0 +1,24 @@
+
+<?php $this->extend('block_unsearchable'); ?>
+
+<?php $this->block('content'); ?>
+
+  <?php if ($this->videoSplash): ?>
+    <figure id="videoSplash<?= $this->id ?>" class="image_container" data-video="<?= $this->src ?>">
+      <?php $this->insert('picture_default', $this->splashImage->picture); ?>
+    </figure>
+    <script>
+      document.getElementById('videoSplash<?= $this->id ?>').addEventListener('click', function(e) {
+        var iframe = document.createElement('iframe');
+        iframe.src = this.dataset['video'];
+        iframe.width = <?= $this->width; ?>;
+        iframe.height = <?= $this->height; ?>;
+        iframe.allowfullscreen = '';
+        this.parentNode.replaceChild(iframe, this);
+      });
+    </script>
+  <?php else: ?>
+    <iframe<?= $this->size ?> src="<?= $this->src ?>" allowfullscreen></iframe>
+  <?php endif; ?>
+
+<?php $this->endblock(); ?>


### PR DESCRIPTION
This PR implements #8 (also for Vimeo). 

![screenshot-2018-5-12 articles home content elements edit content element id 10 - contao open source cms](https://user-images.githubusercontent.com/4970961/39956551-3352dbf8-55e3-11e8-8327-70b1e06698a0.png)

Example output:
```html
<!-- indexer::stop -->
<div class="ce_youtube first block">
  <figure id="videoSplash1" class="image_container" data-video="https://www.youtube.com/embed/Hq9dQXUCFzk?autoplay=1">
    <img src="assets/images/e/image-cd3970d6.jpg" width="640" height="360" alt="" itemprop="image">
    <script>
      window.respimage && window.respimage({
        elements: [document.images[document.images.length - 1]]
      });
    </script>
  </figure>
  <script>
      document.getElementById('videoSplash1').addEventListener('click', function(e) {
        var iframe = document.createElement('iframe');
        iframe.src = this.dataset['video'];
        iframe.width = <?= $this->width; ?>;
        iframe.height = <?= $this->height; ?>;
        iframe.allowfullscreen = '';
        this.parentNode.replaceChild(iframe, this);
      });
  </script>
</div>
<!-- indexer::continue -->
```
